### PR TITLE
Put Opening environment message back to the success message list

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -46,7 +46,7 @@ push_to_secondary_remote() {
      git remote add secondary-remote ${MAGENTO_CLOUD_REMOTE}
      # Fail pipeline on Magento Cloud failure (no appropriate status codes from git push)
      # and print output to bitbucket pipeline stream.
-     git push secondary-remote ${BITBUCKET_BRANCH}  2>&1 | tee /dev/stderr | grep -qiE "Everything up-to-date|Deployment completed?|Warmed up page"
+     git push secondary-remote ${BITBUCKET_BRANCH}  2>&1 | tee /dev/stderr | grep -qiE "Opening environment|Everything up-to-date|Deployment completed?|Warmed up page"
 }
 
 validate


### PR DESCRIPTION
Pipelines report failing when it can't find any other strings in the list. I will revisit this one, with the option of negating the message. 