### PR TITLE
DO-1337: Fix tee command to output to pipeline

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -49,7 +49,7 @@ push_to_secondary_remote() {
     OUTFILE="/tmp/git_push_output"
     SUCCESS_TEXT=("Everything up-to-date" "Deployment completed" "Warmed up page" "Opening environment")
     FAIL_TEXT=("Deploy was failed" "Post deploy is skipped")
-    git push secondary-remote ${BITBUCKET_BRANCH}  2>&1 | tee >/dev/stout >${OUTFILE}
+    git push secondary-remote ${BITBUCKET_BRANCH} 2>&1 | tee ${OUTFILE} >/dev/stderr
 
     for text in "${FAIL_TEXT[@]}"
     do


### PR DESCRIPTION
Changed the order of the `tee` arguments and changed the typo of `/dev/stout` to `/dev/stderr`. It was previously using `stderr`.