### PR TITLE
Allow function chain to flow by not exiting the shell

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -53,15 +53,15 @@ push_to_secondary_remote() {
 
     for text in "${FAIL_TEXT[@]}"
     do
-        cat $OUTFILE | grep -iqE "${text}" && exit 1
+        cat $OUTFILE | grep -iqE "${text}" && return 1
     done
 
     for text in "${SUCCESS_TEXT[@]}"
     do
-        cat $OUTFILE | grep -iqE "${text}" && exit 0
+        cat $OUTFILE | grep -iqE "${text}" && return 0
     done
 
-    exit 1
+    return 1
 }
 
 mute_nr_alerts() {


### PR DESCRIPTION
With "exit" the function chain at line #99 doesn't work. This change will allow them to flow again. 