### PR TITLE
Add support for custom remote branch

### DIFF
--- a/pipe/pipe.sh
+++ b/pipe/pipe.sh
@@ -49,7 +49,8 @@ push_to_secondary_remote() {
     OUTFILE="/tmp/git_push_output"
     SUCCESS_TEXT=("Everything up-to-date" "Deployment completed" "Warmed up page" "Opening environment")
     FAIL_TEXT=("Deploy was failed" "Post deploy is skipped")
-    git push secondary-remote ${BITBUCKET_BRANCH} 2>&1 | tee ${OUTFILE} >/dev/stderr
+    BRANCH="${BITBUCKET_BRANCH}${REMOTE_BRANCH:+:$REMOTE_BRANCH}"
+    git push secondary-remote ${BRANCH} 2>&1 | tee ${OUTFILE} >/dev/stderr
 
     for text in "${FAIL_TEXT[@]}"
     do


### PR DESCRIPTION
Adds support for a custom remote branch. Currently it is assumed that the host uses the same branch name as the source.

A use-case for a custom remote branch is deploying to alternative hosting providers. I would like to deploy the staging branch (from BitBucket) to the master branch in the hosting provider.

The default behaviour has not changed. When the remote branch is null, it will push to the remote branch with the same name and the source branch. 