### PR TITLE
AKD-385: add DockerHub build hook for ALPINE_VERSION arg

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+docker build \
+    --build-arg ALPINE_VERSION="${ALPINE_VERSION:?ALPINE_VERSION is required}" \
+    -t "$IMAGE_NAME" \
+    .


### PR DESCRIPTION

**Description of the proposed changes**

DockerHub environment variables don't automatically become build args. This hook script passes ALPINE_VERSION to docker build explicitly.

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/.github/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

**Time Tracking**

ABC-xxx: code review, select project XXXX